### PR TITLE
Redirect from github pages to adobe.io

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+import {withPrefix} from 'gatsby';
+
+export const onRenderBody = ({setHeadComponents}) => {
+  setHeadComponents([
+    <script src={withPrefix('/redirections.js')}></script>
+  ]);
+};

--- a/static/redirections.js
+++ b/static/redirections.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+(() => {
+    // if on github pages, redirect to adobe.io
+  if(window.location.host === 'adobedocs.github.io') {
+    window.location.host = 'adobe.io';
+  }
+})();


### PR DESCRIPTION
Hey @bdenham - this is a fix for redirecting from github pages to the main site. 