### PR TITLE
Reverted theme down a couple of dot versions to avoid recent theme bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/bdenham"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "^3.23.4",
+    "@adobe/gatsby-theme-aio": "^3.23.1",
     "gatsby": "^3.6.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/bdenham"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "^3.23.1",
+    "@adobe/gatsby-theme-aio": "3.23.1",
     "gatsby": "^3.6.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"


### PR DESCRIPTION
## Description

The latest adobeio theme — 3.23.4 — introduces a bug. This PR sets the adobeio theme version for this repo down to 3.23.1, to avoid a breaking build upon deployment.
