### PR TITLE
Convert add-to-project-board to reusable workflow

### DIFF
--- a/.github/workflows/add-to-project-board.yml
+++ b/.github/workflows/add-to-project-board.yml
@@ -1,0 +1,16 @@
+##### Aggregate Commerce PRs and Issues into a respective Organizational Project #####
+
+name: Add pull requests and issues to projects
+
+on:
+  pull_request_target:
+    types:
+      - opened
+  issues:
+    types: 
+      - opened
+
+jobs:
+  call-workflow-add-to-project:
+    uses: AdobeDocs/commerce-php/.github/workflows/add-to-project_job.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Purpose of this pull request

This pull request converts a workflow _Add pull requests and issues to projects_ for using a reusable workflow at [AdobeDocs/commerce-php/.github/workflows/add-to-project_job.yml](https://github.com/AdobeDocs/commerce-php/blob/main/.github/workflows/add-to-project_job.yml).

## Affected pages

none

## Additional information

Internal ref: COMDOX-515
