### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get pathPrefix
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: get_path_prefix
         with:
           script: |

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -24,7 +24,7 @@
           uses: actions/checkout@v4
   
         - name: Get pathPrefix
-          uses: actions/github-script@v6
+          uses: actions/github-script@v7
           id: get_path_prefix
           with:
             script: |

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -60,7 +60,7 @@
           # Use full version number to avoid cases when a next
           # released version is buggy
           # About slim image: https://github.com/github/super-linter#slim-image
-          uses: super-linter/super-linter/slim@v7.0.0
+          uses: super-linter/super-linter/slim@v7.2.0
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             DEFAULT_BRANCH: main

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "serve": "NODE_OPTIONS='--max-old-space-size=8192' gatsby serve",
     "clean": "gatsby clean",
     "test:md": "markdownlint src/pages",
-    "test": "remark src/pages --quiet --frail",
-    "lint": "docker run --rm -e RUN_LOCAL=true --env-file .github/super-linter.env -v \"$PWD\":/tmp/lint github/super-linter:slim-v5"
+    "test": "remark src/pages --quiet --frail"
   },
   "packageManager": "yarn@3.2.4"
 }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the GH actions as the follwing:
- Upgrade outdated GH action
  ```
  .github/workflows/publish.yml:18:15: the runner of "actions/github-script@v6" action is too old to run on GitHub Actions. 
  update the action's version to fix this issue [action]
       |
    18 |         uses: actions/github-script@v6
       |               ^~~~~~~~~~~~~~~~~~~~~~~~
    .github/workflows/stage.yml:20:17: the runner of "actions/github-script@v6" action is too old to run on GitHub Actions. 
  update the action's version to fix this issue [action]
       |
    20 |           uses: actions/github-script@v6
       |                 ^~~~~~~~~~~~~~~~~~~~~~~~
  ```
- Upgrade SuperLinter
- Delete the local script unsupported for ARM architecture
 
## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- none

## Testing

Successfully build staging: https://developer-stage.adobe.com/commerce-xd-kits/